### PR TITLE
fixing styles path

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -59,7 +59,7 @@
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.css"
+              "projects/counterelement/src/styles.css"
             ],
             "scripts": [
               {
@@ -192,7 +192,7 @@
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.css"
+              "projects/counterelement/src/styles.css"
             ],
             "scripts": [
               {


### PR DESCRIPTION
This should fix the following error:

```
ERROR in multi [...]/ngRxElementDemo/node_modules/@angular/material/prebuilt-themes/indigo-pink.css [...]/ngRxElementDemo/src/styles.css 
Module not found: Error: Can't resolve '[...]/ngRxElementDemo/src/styles.css' in '[...]/ngRxElementDemo/projects/counterelement'
```